### PR TITLE
why goroutine

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,9 +30,7 @@ func main() {
 	fmt.Println("\nday 2, part 1")
 	day2.Part1(input_dir)
 
-	fmt.Println("\nday 2, part 2")
-	day2_answer, _ := day2.Part2(day_input(2, input_dir))
-	fmt.Printf("answer: %d\n", day2_answer)
+	puzzle_print(1, 2, day2.Part2, input_dir)
 }
 
 func intro() {
@@ -48,7 +46,11 @@ func intro() {
   ` + "`" + `Y8bood8P'    ` + "`" + `Y8bood8P'` + "\n\n")
 }
 
-func day_input(day int, input_dir string) *iterable.IterableFile {
+type PuzzlePart func(input iterable.StringIterator) (int, error)
+
+func puzzle_print(day int, part int, fn PuzzlePart, input_dir string) {
+	fmt.Printf("\nday %d, part %d", day, part)
 	input_path := filepath.Join(util.CurrentDir(), input_dir, fmt.Sprintf("day%d/input.txt", day))
-	return iterable.NewIterableFile(input_path)
+	answer, _ := fn(iterable.NewIterableFile(input_path))
+	fmt.Printf("answer: %d\n", answer)
 }


### PR DESCRIPTION
output/error from this change:

```
...
day 1, part 2panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/walrusk/aoc2021/pkg/day2.Part2({0x10cc860, 0xc0000962f0})
	/Users/philae1/repos/aoc2021/pkg/day2/part2.go:24 +0x1e5
main.puzzle_print(0x7ffeefbff7a9, 0x7, 0x10b5370, {0x7ffeefbff7a9, 0x7})
	/Users/philae1/repos/aoc2021/main.go:54 +0x1b0
main.main()
	/Users/philae1/repos/aoc2021/main.go:33 +0x1d4
exit status 2
```

why does passing the fn `day2.Part2` as an arg seem to trigger it as a go routine and error?